### PR TITLE
Fix admin all api call bug

### DIFF
--- a/frontend/src/app/common/services/comic.service.ts
+++ b/frontend/src/app/common/services/comic.service.ts
@@ -17,7 +17,7 @@ export class ComicService {
 
   getAllComicsAdmin() {
     return this.http
-      .get(`${environment.apiHost}/comics/admin/all`)
+      .get(`${environment.apiHost}/admin/comics/all`)
       .pipe(map((res) => res));
   }
 


### PR DESCRIPTION
# Bugfix

Fix Admin API endpoint that shows all comics. Was bugged in comic service as wrong path in `getAllComicsAdmin`